### PR TITLE
[CTX-34482] Optimize discovery request calls and HTTP response handling.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+cytaxii2/__pycache__/

--- a/cytaxii2/__init__.py
+++ b/cytaxii2/__init__.py
@@ -1,4 +1,5 @@
 from . import cytaxii2
+from .cytaxii2 import clear_api_root_cache
 """
 Cyware TAXII 2 Client.
 
@@ -7,6 +8,7 @@ to connect to a TAXII 2 Server and perform actions
 """
 __all__ = [
     'cytaxii2',
+    'clear_api_root_cache',
 ]
 __version__ = '1.0.0'
 __author__ = 'Cyware Labs'

--- a/cytaxii2/cytaxii2.py
+++ b/cytaxii2/cytaxii2.py
@@ -1,12 +1,32 @@
+import threading
 import requests
 
 """
 Cyware TAXII 2.0/ 2.1 Client 
 TAXII Supported Version: 2.0 & 2.1
+
+The client caches the default API root after the first successful discovery.
+Reuse the same client instance for multiple requests to avoid repeated discovery.
 """
+
+# Cache API root by discovery_url so even new client instances avoid repeated discovery.
+# Guarded by a lock for thread safety. Use clear_api_root_cache() to reset (e.g. in tests).
+_api_root_cache = {}
+_api_root_cache_lock = threading.Lock()
+
+
+def clear_api_root_cache():
+    """Clear the shared API root cache. Use when the server's default API root may have changed."""
+    with _api_root_cache_lock:
+        _api_root_cache.clear()
 
 
 class cytaxii2(object):
+    """
+    TAXII 2.x client. Caches the API root after first discovery; reuse this
+    instance for multiple requests to avoid repeated discovery calls.
+    """
+
     def __init__(self, discovery_url, username, password, version=2.1, **kwargs):
         """
         This method is used to initialize values throughout the class
@@ -35,46 +55,87 @@ class cytaxii2(object):
         self.collections = "collections"
         self.objects = "objects"
 
-    def request_handler(self, method, url, json_data=None, query_params=None, **kwargs):
+    def request_handler(self, method, url, json_data=None, query_params=None, timeout=30, **kwargs):
         """
-        This method is used to handle all TAXII requests
-        :param query_params: Any query params to pass
-        :param method: Enter the HTTP method to use
-        :param url: Enter the URL to make the request to
-        :param json_data: Enter the json data to pass as a payload
+        Perform an HTTP request. Never raises. Returns status, status_code, response, headers.
+
+        status_code is always set: HTTP code when a response was received (e.g. 429),
+        or 500 when the request failed before any response.
+
+        When response.ok is False, we still try to parse JSON; if the body is not
+        valid JSON we do not raise—we return status_code and a clear message string
+        (including the code), so 429 and other flux errors are visible.
+
+        response: parsed JSON (dict/list) on success or when server returned JSON;
+        otherwise a string (405 message, exception message, or parse error with status).
+
+        headers: when an HTTP response was received, a dict of response header names
+        to values (e.g. Retry-After, WWW-Authenticate, X-RateLimit-*); None when no
+        response (e.g. connection error). Use for backoff, auth challenges, rate limits.
+
+        timeout: passed to requests (default 30 seconds). Override via kwargs or this argument.
+        **kwargs: forwarded to requests.get/post (e.g. timeout, verify).
         """
+        if method not in ('GET', 'POST'):
+            return {
+                'status': False,
+                'status_code': 405,
+                'response': 'Unsupported Method requested',
+                'headers': None,
+            }
+
+        req_kwargs = {'url': url, 'headers': self.headers, 'auth': self.auth, 'timeout': timeout, **kwargs}
+        if method == 'GET':
+            req_kwargs['params'] = query_params
+            if json_data is not None:
+                req_kwargs['data'] = json_data
+        else:
+            req_kwargs['params'] = query_params
+            if isinstance(json_data, (dict, list)):
+                req_kwargs['json'] = json_data
+            elif json_data is not None:
+                req_kwargs['data'] = json_data
+
         try:
             if method == 'GET':
-                response = requests.get(url=url, data=json_data, headers=self.headers, auth=self.auth,
-                                        params=query_params)
-            elif method == 'POST':
-                response = requests.post(url=url, data=json_data, headers=self.headers, auth=self.auth,
-                                         params=query_params)
+                response = requests.get(**req_kwargs)
             else:
-                return {
-                    'response': 'Unsupported Method requested',
-                    'status': False,
-                    'status_code': 405
-                }
+                response = requests.post(**req_kwargs)
+        except requests.RequestException as e:
+            return {
+                'status': False,
+                'status_code': 500,
+                'response': str(e),
+                'headers': None,
+            }
 
-            status_code = response.status_code
+        status_code = response.status_code
+        body = response.text or ''
+        response_headers = dict(response.headers)
 
-            if response.ok:
-                response_json = response.json()
-                status = True
-            else:
-                response_json = response.json()
-                status = False
+        try:
+            response_json = response.json() if body.strip() else None
+        except (ValueError, TypeError) as e:
+            raw_preview_len = 4096
+            raw_preview = (body[:raw_preview_len] + '...') if len(body) > raw_preview_len else body
+            err_msg = 'Invalid JSON: {} (HTTP {}). Raw response: {}'.format(
+                e, status_code, raw_preview
+            )
+            return {
+                'status': False,
+                'status_code': status_code,
+                'response': err_msg,
+                'headers': response_headers,
+            }
 
-        except Exception as e:
-            status_code = 'EXCEPTION'
-            response_json = str(e)
-            status = False
-
+        status = True if response.ok else False
+        if not response.ok and response_json is None:
+            response_json = ""
         return {
-            'response': response_json,
             'status': status,
-            'status_code': status_code
+            'status_code': status_code,
+            'response': response_json,
+            'headers': response_headers,
         }
 
     def discovery_request(self, **kwargs):
@@ -86,20 +147,36 @@ class cytaxii2(object):
 
     def get_api_root(self, **kwargs):
         """
-        This method is used to manage retreiving the default API root for TAXII server.
+        Return the default API root for the TAXII server. The result is cached:
+        - on this instance (self.api_root), and
+        - by discovery_url (shared across instances for the same server),
+        so discovery_request() is only called once per server. Reuse the same
+        client instance when possible to avoid extra work.
 
         Returns
         :api_root (str): api root default if available, otherwise discover_request() response
         :early_return (bool): False if API root found, otherwise True (bad discover_request)
         """
-        if not self.api_root:
-            discover_response = self.discovery_request()
-            if discover_response['status_code'] == 200:
-                self.api_root = discover_response['response']['default']
-            else:
+        if self.api_root:
+            return self.api_root, False
+        with _api_root_cache_lock:
+            if self.discovery_url in _api_root_cache:
+                self.api_root = _api_root_cache[self.discovery_url]
+                return self.api_root, False
+        discover_response = self.discovery_request()
+        resp = discover_response.get('response')
+        if discover_response.get('status_code') == 200 and isinstance(resp, dict) and 'default' in resp:
+            root = resp['default']
+            if not isinstance(root, str) or not root.strip():
                 return discover_response, True
-
-        return self.api_root, False
+            with _api_root_cache_lock:
+                if self.discovery_url in _api_root_cache:
+                    self.api_root = _api_root_cache[self.discovery_url]
+                else:
+                    _api_root_cache[self.discovery_url] = root
+                    self.api_root = root
+            return self.api_root, False
+        return discover_response, True
 
     def root_discovery(self, **kwargs):
         """

--- a/sample_feed_pull_inbox.py
+++ b/sample_feed_pull_inbox.py
@@ -6,7 +6,7 @@ Sample script: TAXII 2.1 feed Pull and Inbox using cytaxii2.
 - Downloaded feed is saved as: {collection_id}_{timestamp}.json
 - Uses STIX 2.1 / TAXII 2.1.
 - Script options #3 & #4 are used to test rate limiting. Configure TAXII server 
-  limit to 10 requests per minut.
+  limit to 10 requests per minute.
 """
 
 import json

--- a/sample_feed_pull_inbox.py
+++ b/sample_feed_pull_inbox.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""
+Sample script: TAXII 2.1 feed Pull and Inbox using cytaxii2.
+
+- User selects action: Pull (get objects from a collection) or Inbox (post a STIX bundle).
+- Downloaded feed is saved as: {collection_id}_{timestamp}.json
+- Uses STIX 2.1 / TAXII 2.1.
+- Script options #3 & #4 are used to test rate limiting. Configure TAXII server 
+  limit to 10 requests per minut.
+"""
+
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+# -----------------------------------------------------------------------------
+# Placeholders — set these before running
+# -----------------------------------------------------------------------------
+DISCOVERY_URL = ""  # TAXII 2.1 Discovery URL
+USERNAME = ""       # Basic auth username
+PASSWORD = ""       # Basic auth password
+# -----------------------------------------------------------------------------
+
+# Optional: directory where to save pulled feeds (default: current directory)
+OUTPUT_DIR = "."
+
+# Set to 1 to print full server response (status, status_code, response) after each request; 0 to skip (STIX output is long).
+DEBUG = 0
+
+
+def get_timestamp():
+    return datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+
+
+def safe_feed_id(collection_id):
+    """Make collection_id safe for use in a filename."""
+    if not collection_id:
+        return "feed"
+    return "".join(c if c.isalnum() or c in "-_" else "_" for c in collection_id)
+
+
+def print_response_headers(label, result):
+    """Print response headers (e.g. Retry-After, rate limit info). Used in regular mode."""
+    headers = result.get("headers")
+    if not headers:
+        return
+    print("\n--- {} (headers) ---".format(label))
+    for k, v in sorted(headers.items()):
+        print("  {}: {}".format(k, v))
+    print("---\n")
+
+
+def print_server_response(label, result):
+    """Always print the full server response (status, status_code, headers, response) for debugging."""
+    print("\n--- {} ---".format(label))
+    print("status: {}".format(result.get("status")))
+    print("status_code: {}".format(result.get("status_code")))
+    headers = result.get("headers")
+    if headers:
+        print("headers:")
+        for k, v in sorted(headers.items()):
+            print("  {}: {}".format(k, v))
+    resp = result.get("response")
+    if isinstance(resp, (dict, list)):
+        print("response:\n{}".format(json.dumps(resp, indent=2)))
+    else:
+        print("response: {}".format(resp))
+    print("---\n")
+
+
+def main():
+    # Use lib from this repo first (no install needed after git clone), then installed
+    _project_root = os.path.dirname(os.path.realpath(__file__))
+    sys.path.insert(0, _project_root)
+    try:
+        from cytaxii2.cytaxii2 import cytaxii2
+    except ImportError as e:
+        err = str(e)
+        if "requests" in err or "No module named" in err:
+            print("Missing dependency. From repo root: pip install -r requirements.txt", file=sys.stderr)
+        else:
+            print("cytaxii2 not found. Run from repo root or install: pip install -e .", file=sys.stderr)
+        print("  ({})".format(e), file=sys.stderr)
+        sys.exit(1)
+
+    client = cytaxii2(
+        discovery_url=DISCOVERY_URL,
+        username=USERNAME,
+        password=PASSWORD,
+        version=2.1,
+    )
+
+    # Discovery: get API root and list collections
+    print("Performing discovery...")
+    collections_resp = client.collection_request()
+    if DEBUG:
+        print_server_response("collection_request", collections_resp)
+    else:
+        print_response_headers("collection_request", collections_resp)
+    if not collections_resp.get("status"):
+        r = collections_resp.get("response") or {}
+        msg = r.get("error", r) if isinstance(r, dict) else r
+        print("Failed to get collections (status_code={}): {}".format(
+            collections_resp.get("status_code"), msg), file=sys.stderr)
+        sys.exit(1)
+
+    collections = (collections_resp.get("response") or {}).get("collections", [])
+    if not collections:
+        print("No collections found.")
+        sys.exit(1)
+
+    print("\nAvailable collections:")
+    for i, col in enumerate(collections, 1):
+        print("  {}: {} (id: {})".format(i, col.get("title", "—"), col.get("id", "—")))
+
+    sel = input("Select collection (enter number or collection id): ").strip()
+    collection_id = None
+    for i, c in enumerate(collections, 1):
+        if c.get("id") == sel or sel == str(i):
+            collection_id = c.get("id")
+            break
+    if not collection_id and sel:
+        collection_id = sel  # user typed an id that wasn't in the list
+    elif not collection_id:
+        collection_id = collections[0].get("id")
+
+    print("\nTAXII 2.1 – Pull / Inbox (STIX 2.1)")
+    print("1) Pull  – get objects from this collection (save to file)")
+    print("2) Inbox – post a STIX 2.1 bundle to this collection")
+    print("3) Loop  – 15 poll requests (no save)")
+    print("4) Loop  – 15 inbox requests")
+    choice = input("Select action (1–4): ").strip()
+
+    if choice not in ("1", "2", "3", "4"):
+        print("Invalid choice. Exiting.")
+        sys.exit(1)
+
+    if choice == "1":
+        # --- Pull ---
+        added_after = input("Optional added_after (ISO8601, or Enter to skip): ").strip() or None
+        limit_str = input("Optional limit (or Enter to skip): ").strip()
+        limit = int(limit_str) if limit_str.isdigit() else None
+
+        poll_resp = client.poll_request(
+            collection_id=collection_id,
+            added_after=added_after,
+            limit=limit,
+        )
+        if DEBUG:
+            print_server_response("poll_request", poll_resp)
+        else:
+            print_response_headers("poll_request", poll_resp)
+        if not poll_resp.get("status"):
+            r = poll_resp.get("response") or {}
+            msg = r.get("error", r) if isinstance(r, dict) else r
+            print("Poll failed (status_code={}): {}".format(
+                poll_resp.get("status_code"), msg), file=sys.stderr)
+            sys.exit(1)
+
+        filename = "{}_{}.json".format(safe_feed_id(collection_id), get_timestamp())
+        out_path = os.path.join(OUTPUT_DIR, filename) if OUTPUT_DIR else filename
+        out_dir = os.path.dirname(out_path)
+        if out_dir:
+            os.makedirs(out_dir, exist_ok=True)
+        payload = poll_resp.get("response")
+        with open(out_path, "w", encoding="utf-8") as f:
+            json.dump(payload if payload is not None else {}, f, indent=2)
+        print("Saved pull response to:", out_path)
+
+    elif choice == "2":
+        # --- Inbox ---
+        bundle_path = input("Path to STIX 2.1 bundle JSON file: ").strip()
+        if not bundle_path:
+            print("No file path given. Exiting.")
+            sys.exit(1)
+        try:
+            with open(bundle_path, encoding="utf-8") as f:
+                raw = f.read()
+        except (OSError, UnicodeDecodeError) as e:
+            print("Failed to read bundle file {}: {}".format(bundle_path, e), file=sys.stderr)
+            sys.exit(1)
+
+        # Library POST uses data= for string or json= for dict
+        inbox_resp = client.inbox_request(collection_id=collection_id, stix_bundle=raw)
+        if DEBUG:
+            print_server_response("inbox_request", inbox_resp)
+        else:
+            print_response_headers("inbox_request", inbox_resp)
+        if not inbox_resp.get("status"):
+            r = inbox_resp.get("response") or {}
+            msg = r.get("error", r) if isinstance(r, dict) else r
+            print("Inbox request failed (status_code={}): {}".format(
+                inbox_resp.get("status_code"), msg), file=sys.stderr)
+            sys.exit(1)
+        payload = inbox_resp.get("response")
+        print("Inbox response:", json.dumps(payload if payload is not None else {}, indent=2))
+
+    elif choice == "3":
+        # --- Loop: 15 poll requests ---
+        for i in range(1, 16):
+            poll_resp = client.poll_request(collection_id=collection_id)
+            print("Poll request {}/15: status={}, status_code={}".format(
+                i, poll_resp.get("status"), poll_resp.get("status_code")))
+            if DEBUG:
+                print_server_response("poll_request #{}".format(i), poll_resp)
+            else:
+                print_response_headers("poll_request #{}".format(i), poll_resp)
+            if not poll_resp.get("status"):
+                r = poll_resp.get("response") or {}
+                msg = r.get("error", r) if isinstance(r, dict) else r
+                print("Poll failed (status_code={}): {}".format(
+                    poll_resp.get("status_code"), msg), file=sys.stderr)
+        print("Done: 15 poll requests completed.")
+
+    elif choice == "4":
+        # --- Loop: 15 inbox requests ---
+        bundle_path = input("Path to STIX 2.1 bundle JSON file: ").strip()
+        if not bundle_path:
+            print("No file path given. Exiting.")
+            sys.exit(1)
+        try:
+            with open(bundle_path, encoding="utf-8") as f:
+                raw = f.read()
+        except (OSError, UnicodeDecodeError) as e:
+            print("Failed to read bundle file {}: {}".format(bundle_path, e), file=sys.stderr)
+            sys.exit(1)
+        for i in range(1, 16):
+            inbox_resp = client.inbox_request(collection_id=collection_id, stix_bundle=raw)
+            print("Inbox request {}/15: status={}, status_code={}".format(
+                i, inbox_resp.get("status"), inbox_resp.get("status_code")))
+            if DEBUG:
+                print_server_response("inbox_request #{}".format(i), inbox_resp)
+            else:
+                print_response_headers("inbox_request #{}".format(i), inbox_resp)
+            if not inbox_resp.get("status"):
+                r = inbox_resp.get("response") or {}
+                msg = r.get("error", r) if isinstance(r, dict) else r
+                print("Inbox failed (status_code={}): {}".format(
+                    inbox_resp.get("status_code"), msg), file=sys.stderr)
+        print("Done: 15 inbox requests completed.")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## **User description**
**Response headers in return value**
Every return from request_handler now includes a headers key: a dict of response headers when an HTTP response was received, or None on connection error. Callers can use it for Retry-After, rate limits, and other headers without parsing the body.

**Control flow and errors**

- Method handling simplified to a single check for GET/POST and one early return for unsupported method (with headers: None).
- Only requests.RequestException is caught; no generic Exception and no status_code = 'EXCEPTION'. On request failure we return status_code=500, error message, and headers=None.
- After a response is received we always set status_code, body, and response_headers = dict(response.headers).
- JSON and non-JSON bodies
- JSON is parsed in a try/except. On parse failure we still return status_code, the error message, and headers so callers get headers (e.g. Retry-After on 429) even when the body is not JSON.

**Success return**
Return dict is now consistently status, status_code, response, and headers (including on non-OK responses).

**get_api_root – shared cache and flow**

Process-level cache
- API root is cached by discovery_url in a shared, lock-protected cache (_api_root_cache / _api_root_cache_lock), so multiple client instances for the same server reuse one discovery result.

Lookup order
- Uses instance self.api_root first, then the shared cache, then performs discovery and stores the result in both the instance and the cache on success.
 
Return value
- Success: (self.api_root, False). Failure: (discover_response, True). Logic is aligned so callers always get this shape.

**Added sample client**
- Sample client can perform Pull and Inbox requests
- Options 3 & 4 allow to test rate limit behavior for Inbox and Poll requests


___

## **CodeAnt-AI Description**
Cache API root across instances and include HTTP response headers in all request results

### What Changed
- Discovery result (default API root) is cached by discovery URL and reused across client instances; a clear_api_root_cache() function is provided to reset the shared cache.
- HTTP requests never raise: results always include status (success/failure), status_code (HTTP code or 500 on connection error), response (parsed JSON or a readable string), and headers (dict of response headers when a response was received, otherwise None).
- Non-JSON or malformed response bodies are reported as a clear error message while still returning response headers so callers can inspect Retry-After and rate-limit information.
- Added a sample CLI script to perform Pull and Inbox actions and to exercise rate-limit scenarios; package exports clear_api_root_cache.

### Impact
`✅ Fewer discovery requests when reusing clients or multiple instances`
`✅ Clearer access to Retry-After and rate-limit headers for backoff`
`✅ No unhandled errors on non-JSON responses (returns readable error and headers)`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
